### PR TITLE
Changed second Twig Filter header to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Minimee's template variable is attached to Craft's global variable `{{ craft }}`
 	}}
 
 
-##### CSS:
+##### JS:
 
 	{{ craft.minimee.js([
 			'/assets/js/jquery.js',


### PR DESCRIPTION
Changed second header from CSS to JS under 2. Twig Filter to properly denote what the code is demonstrating.
